### PR TITLE
Fixing bug preventing directives on link tags from being processed

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ mod.directive('headExtend', [
           return {tmpl: $compile(meta.outerHTML), orig: origMetas[name]};
         });
 
-        var links = Array.prototype.map.call(tEl.find('link'), $compile);
+        var links = Array.prototype.map.call(tEl.find('link'), function(link) {
+          return $compile(link.outerHTML);
+        });
 
         tEl.html('');
         var html = $compile(tEl[0].outerHTML.replace('head-extend', 'div'));


### PR DESCRIPTION
For some reason, when an element is passed to $compile rather than the outerHTML string, directives on the element are not executed when the returned template is executed and added to the DOM. Hence, the change to passing outerHTML instead of the link element.
